### PR TITLE
feat: branch workflow enforcement and auto-tag CI

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,83 @@
+name: Auto Tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        run: |
+          # Get the latest version tag
+          LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "new_tag=v0.1.0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Latest tag: $LATEST_TAG"
+
+          # Strip the 'v' prefix and split into parts
+          VERSION="${LATEST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          # Get commits since last tag
+          COMMITS=$(git log "$LATEST_TAG"..HEAD --pretty=format:"%s" --no-merges)
+
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits since $LATEST_TAG, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Commits since $LATEST_TAG:"
+          echo "$COMMITS"
+
+          # Determine bump type from conventional commits
+          BUMP="patch"
+          if echo "$COMMITS" | grep -qiE "^(feat|feature)(\(.+\))?!:|BREAKING CHANGE:"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qiE "^(feat|feature)(\(.+\))?:"; then
+            BUMP="minor"
+          fi
+
+          echo "Bump type: $BUMP"
+
+          case "$BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "New tag: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          git tag "${{ steps.bump.outputs.new_tag }}"
+          git push origin "${{ steps.bump.outputs.new_tag }}"

--- a/internal/hooks/branch_guard.go
+++ b/internal/hooks/branch_guard.go
@@ -1,0 +1,168 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+)
+
+func init() {
+	Register("branch-guard", branchGuardHook)
+}
+
+// branchGuardHook enforces the branch-based PR workflow. It handles two events:
+//   - SessionStart: injects a reminder about the branching workflow if on main
+//   - PreToolUse (Bash): blocks git commit/push operations when on the main branch
+func branchGuardHook(input *Input) error {
+	switch input.HookEventName {
+	case "SessionStart":
+		return branchGuardSessionStart(input)
+	case "PreToolUse":
+		return branchGuardPreToolUse(input)
+	default:
+		ExitOK()
+		return nil
+	}
+}
+
+func branchGuardSessionStart(input *Input) error {
+	branch := currentBranch(input.Cwd)
+	if branch == "main" || branch == "master" {
+		WriteOutput(&Output{
+			HookSpecific: &HookSpecificOuput{
+				HookEventName:     "SessionStart",
+				AdditionalContext: "You are currently on the `" + branch + "` branch. Do NOT commit or push directly to this branch. Create a feature branch first (e.g., `git checkout -b feat/my-feature`), then open a PR when ready.",
+			},
+		})
+		return nil
+	}
+	ExitOK()
+	return nil
+}
+
+func branchGuardPreToolUse(input *Input) error {
+	if input.ToolName != "Bash" {
+		ExitOK()
+		return nil
+	}
+
+	var bash BashToolInput
+	if err := json.Unmarshal(input.ToolInput, &bash); err != nil {
+		ExitOK()
+		return nil
+	}
+
+	cmd := strings.TrimSpace(bash.Command)
+	if !isGitCommand(cmd) {
+		ExitOK()
+		return nil
+	}
+
+	// Check for push targeting main regardless of current branch
+	if isPushToMain(cmd) {
+		BlockWithError("Blocked: Do not push directly to main. Push your feature branch and open a PR instead.\n\nExample:\n  git push -u origin feat/my-feature\n  gh pr create")
+		return nil
+	}
+
+	// For commit and push-without-explicit-target, check current branch
+	branch := currentBranch(input.Cwd)
+	if branch != "main" && branch != "master" {
+		ExitOK()
+		return nil
+	}
+
+	if isGitCommit(cmd) {
+		BlockWithError("Blocked: Do not commit directly to " + branch + ". Create a feature branch first.\n\nExample:\n  git checkout -b feat/my-feature")
+		return nil
+	}
+
+	if isGitPush(cmd) {
+		BlockWithError("Blocked: Do not push directly to " + branch + ". Push your feature branch and open a PR instead.\n\nExample:\n  git checkout -b feat/my-feature\n  git push -u origin feat/my-feature\n  gh pr create")
+		return nil
+	}
+
+	ExitOK()
+	return nil
+}
+
+// currentBranch returns the current git branch name for the given directory.
+// Returns empty string if git is not available or the directory is not a repo.
+func currentBranch(cwd string) string {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// isGitCommand checks if a command string starts with or contains a git command.
+func isGitCommand(cmd string) bool {
+	// Handle chained commands: "git add . && git commit -m ..."
+	parts := splitChainedCommands(cmd)
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if strings.HasPrefix(trimmed, "git ") || trimmed == "git" {
+			return true
+		}
+	}
+	return false
+}
+
+// isGitCommit checks if the command contains a git commit operation.
+func isGitCommit(cmd string) bool {
+	parts := splitChainedCommands(cmd)
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if strings.HasPrefix(trimmed, "git commit") {
+			return true
+		}
+	}
+	return false
+}
+
+// isGitPush checks if the command contains a git push operation.
+func isGitPush(cmd string) bool {
+	parts := splitChainedCommands(cmd)
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if strings.HasPrefix(trimmed, "git push") {
+			return true
+		}
+	}
+	return false
+}
+
+// isPushToMain checks if the command explicitly pushes to main/master.
+func isPushToMain(cmd string) bool {
+	parts := splitChainedCommands(cmd)
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if !strings.HasPrefix(trimmed, "git push") {
+			continue
+		}
+		// Check for "git push origin main" or "git push origin master"
+		words := strings.Fields(trimmed)
+		for i, w := range words {
+			if i > 1 && (w == "main" || w == "master") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// splitChainedCommands splits a shell command string on && and ; delimiters.
+func splitChainedCommands(cmd string) []string {
+	// Split on && first, then on ;
+	var results []string
+	for _, part := range strings.Split(cmd, "&&") {
+		for _, sub := range strings.Split(part, ";") {
+			results = append(results, sub)
+		}
+	}
+	return results
+}

--- a/internal/hooks/branch_guard_test.go
+++ b/internal/hooks/branch_guard_test.go
@@ -1,0 +1,109 @@
+package hooks
+
+import "testing"
+
+func TestIsGitCommand(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"git status", true},
+		{"git commit -m 'test'", true},
+		{"git add . && git commit -m 'test'", true},
+		{"ls -la", false},
+		{"echo git", false},
+		{"go test ./...", false},
+		{"git", true},
+		{"  git push", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := isGitCommand(tt.cmd); got != tt.want {
+				t.Errorf("isGitCommand(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGitCommit(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"git commit -m 'test'", true},
+		{"git commit --amend", true},
+		{"git add . && git commit -m 'test'", true},
+		{"git push", false},
+		{"git status", false},
+		{"echo 'git commit'", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := isGitCommit(tt.cmd); got != tt.want {
+				t.Errorf("isGitCommit(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGitPush(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"git push", true},
+		{"git push origin feat/my-feature", true},
+		{"git push -u origin feat/my-feature", true},
+		{"git commit -m 'test'", false},
+		{"git status", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := isGitPush(tt.cmd); got != tt.want {
+				t.Errorf("isGitPush(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPushToMain(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"git push origin main", true},
+		{"git push origin master", true},
+		{"git push --force origin main", true},
+		{"git push -u origin feat/my-feature", false},
+		{"git push origin feat/test", false},
+		{"git push", false},
+		{"git commit -m 'main'", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := isPushToMain(tt.cmd); got != tt.want {
+				t.Errorf("isPushToMain(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitChainedCommands(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want int // expected number of parts
+	}{
+		{"git add .", 1},
+		{"git add . && git commit -m 'test'", 2},
+		{"git add .; git commit -m 'test'", 2},
+		{"git add . && git commit -m 'test' && git push", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			parts := splitChainedCommands(tt.cmd)
+			if len(parts) != tt.want {
+				t.Errorf("splitChainedCommands(%q) returned %d parts, want %d", tt.cmd, len(parts), tt.want)
+			}
+		})
+	}
+}

--- a/internal/installer/steps/config_files.go
+++ b/internal/installer/steps/config_files.go
@@ -152,6 +152,16 @@ func hooksConfig(binPath string) map[string]any {
 					},
 				},
 			},
+			{
+				"matcher": "Bash",
+				"hooks": []map[string]any{
+					{
+						"type":    "command",
+						"command": binPath + " hook branch-guard",
+						"timeout": 15,
+					},
+				},
+			},
 		},
 		"PostToolUse": []map[string]any{
 			{
@@ -226,6 +236,15 @@ func hooksConfig(binPath string) map[string]any {
 					{
 						"type":    "command",
 						"command": binPath + " hook session-start",
+						"timeout": 15,
+					},
+				},
+			},
+			{
+				"hooks": []map[string]any{
+					{
+						"type":    "command",
+						"command": binPath + " hook branch-guard",
 						"timeout": 15,
 					},
 				},

--- a/internal/installer/steps/config_files_test.go
+++ b/internal/installer/steps/config_files_test.go
@@ -108,26 +108,28 @@ func TestHooksConfigIncludesSessionStart(t *testing.T) {
 		t.Fatal("hooksConfig should include SessionStart")
 	}
 
-	// Verify SessionStart structure matches SessionEnd pattern
+	// Verify SessionStart structure has entries for session-start and branch-guard
 	startHooks, ok := sessionStart.([]map[string]any)
-	if !ok || len(startHooks) != 1 {
-		t.Fatal("SessionStart should have one hook entry")
+	if !ok || len(startHooks) < 2 {
+		t.Fatalf("SessionStart should have at least 2 hook entries, got %d", len(startHooks))
 	}
 
+	// Verify first entry is session-start
 	hookList, ok := startHooks[0]["hooks"].([]map[string]any)
 	if !ok || len(hookList) != 1 {
-		t.Fatal("SessionStart should have one hook command")
+		t.Fatal("SessionStart first entry should have one hook command")
+	}
+	if hookList[0]["command"] != "/test/bin/picky hook session-start" {
+		t.Errorf("expected session-start command, got %v", hookList[0]["command"])
 	}
 
-	hook := hookList[0]
-	if hook["type"] != "command" {
-		t.Errorf("expected type=command, got %v", hook["type"])
+	// Verify second entry is branch-guard
+	hookList, ok = startHooks[1]["hooks"].([]map[string]any)
+	if !ok || len(hookList) != 1 {
+		t.Fatal("SessionStart second entry should have one hook command")
 	}
-	if hook["command"] != "/test/bin/picky hook session-start" {
-		t.Errorf("expected command with session-start, got %v", hook["command"])
-	}
-	if hook["timeout"] != 15 {
-		t.Errorf("expected timeout=15, got %v", hook["timeout"])
+	if hookList[0]["command"] != "/test/bin/picky hook branch-guard" {
+		t.Errorf("expected branch-guard command, got %v", hookList[0]["command"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Branch-guard hook** (`internal/hooks/branch_guard.go`): Blocks `git commit` and `git push` on `main`/`master` during Claude Code sessions, with helpful messages guiding to feature branches and PRs. Also injects a warning at session start if on main.
- **Auto-tag workflow** (`.github/workflows/auto-tag.yml`): On merge to main, parses conventional commits to determine version bump (major/minor/patch) and creates a new `v*` tag, triggering the existing release pipeline.
- **GitHub Ruleset** configured on main: requires PR with 1 approving review, blocks deletion and force push (admins can bypass).
- **CLAUDE.md** updated with development workflow documentation and release automation details.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests for command parsing (`TestIsGitCommand`, `TestIsGitCommit`, `TestIsGitPush`, `TestIsPushToMain`, `TestSplitChainedCommands`)
- [x] Updated installer config test (`TestHooksConfigIncludesSessionStart`)
- [x] Binary builds cleanly (`make build`)
- [ ] Verify auto-tag workflow triggers on merge of this PR
- [ ] Verify branch-guard blocks commits on main after `picky install`