### PR TITLE
feat: show task completion summary in statusline

### DIFF
--- a/internal/hooks/task_tracker.go
+++ b/internal/hooks/task_tracker.go
@@ -1,0 +1,110 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/jesperpedersen/picky-claude/internal/config"
+)
+
+func init() {
+	Register("task-tracker", taskTrackerHook)
+}
+
+// taskSummary is the JSON structure persisted to {sessionDir}/tasks.json.
+type taskSummary struct {
+	Completed int `json:"completed"`
+	Total     int `json:"total"`
+}
+
+// todoWriteInput matches the TodoWrite tool_input schema.
+type todoWriteInput struct {
+	Todos []todoItem `json:"todos"`
+}
+
+type todoItem struct {
+	Status string `json:"status"`
+}
+
+// taskUpdateInput matches the TaskUpdate tool_input schema.
+type taskUpdateInput struct {
+	Status string `json:"status"`
+}
+
+// taskTrackerHook intercepts TaskCreate, TaskUpdate, and TodoWrite calls
+// to maintain a running task count in the session directory.
+func taskTrackerHook(input *Input) error {
+	sessionID := input.SessionID
+	if sessionID == "" {
+		sessionID = "default"
+	}
+
+	summary := loadTaskSummary(sessionID)
+
+	switch input.ToolName {
+	case "TodoWrite":
+		summary = countFromTodoWrite(input.ToolInput)
+	case "TaskCreate":
+		summary.Total++
+	case "TaskUpdate":
+		var tu taskUpdateInput
+		if err := json.Unmarshal(input.ToolInput, &tu); err == nil {
+			switch tu.Status {
+			case "completed":
+				summary.Completed++
+			case "deleted":
+				if summary.Total > 0 {
+					summary.Total--
+				}
+			}
+		}
+	}
+
+	saveTaskSummary(sessionID, &summary)
+	ExitOK()
+	return nil
+}
+
+// countFromTodoWrite parses a TodoWrite tool_input and counts tasks by status.
+func countFromTodoWrite(raw json.RawMessage) taskSummary {
+	var tw todoWriteInput
+	if err := json.Unmarshal(raw, &tw); err != nil {
+		return taskSummary{}
+	}
+
+	var s taskSummary
+	for _, t := range tw.Todos {
+		switch t.Status {
+		case "completed":
+			s.Completed++
+			s.Total++
+		case "deleted":
+			// don't count deleted
+		default:
+			s.Total++
+		}
+	}
+	return s
+}
+
+func tasksFile(sessionID string) string {
+	return filepath.Join(config.SessionDir(sessionID), "tasks.json")
+}
+
+func loadTaskSummary(sessionID string) taskSummary {
+	data, err := os.ReadFile(tasksFile(sessionID))
+	if err != nil {
+		return taskSummary{}
+	}
+	var s taskSummary
+	json.Unmarshal(data, &s) //nolint:errcheck
+	return s
+}
+
+func saveTaskSummary(sessionID string, s *taskSummary) {
+	dir := config.SessionDir(sessionID)
+	os.MkdirAll(dir, 0o755) //nolint:errcheck
+	data, _ := json.Marshal(s)
+	os.WriteFile(tasksFile(sessionID), data, 0o644) //nolint:errcheck
+}

--- a/internal/hooks/task_tracker_test.go
+++ b/internal/hooks/task_tracker_test.go
@@ -1,0 +1,204 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jesperpedersen/picky-claude/internal/config"
+)
+
+func setupTaskTrackerTest(t *testing.T) (string, func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	orig := os.Getenv(config.EnvPrefix + "_HOME")
+	os.Setenv(config.EnvPrefix+"_HOME", tmpDir)
+	return tmpDir, func() {
+		if orig == "" {
+			os.Unsetenv(config.EnvPrefix + "_HOME")
+		} else {
+			os.Setenv(config.EnvPrefix+"_HOME", orig)
+		}
+	}
+}
+
+func readSummary(t *testing.T, sessionID string) taskSummary {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(config.SessionDir(sessionID), "tasks.json"))
+	if err != nil {
+		t.Fatalf("reading tasks.json: %v", err)
+	}
+	var s taskSummary
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("parsing tasks.json: %v", err)
+	}
+	return s
+}
+
+func TestCountFromTodoWrite(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     todoWriteInput
+		wantDone  int
+		wantTotal int
+	}{
+		{
+			name: "mixed statuses",
+			input: todoWriteInput{
+				Todos: []todoItem{
+					{Status: "completed"},
+					{Status: "pending"},
+					{Status: "in_progress"},
+					{Status: "completed"},
+				},
+			},
+			wantDone:  2,
+			wantTotal: 4,
+		},
+		{
+			name: "all completed",
+			input: todoWriteInput{
+				Todos: []todoItem{
+					{Status: "completed"},
+					{Status: "completed"},
+				},
+			},
+			wantDone:  2,
+			wantTotal: 2,
+		},
+		{
+			name: "none completed",
+			input: todoWriteInput{
+				Todos: []todoItem{
+					{Status: "pending"},
+					{Status: "in_progress"},
+				},
+			},
+			wantDone:  0,
+			wantTotal: 2,
+		},
+		{
+			name: "with deleted",
+			input: todoWriteInput{
+				Todos: []todoItem{
+					{Status: "completed"},
+					{Status: "deleted"},
+					{Status: "pending"},
+				},
+			},
+			wantDone:  1,
+			wantTotal: 2,
+		},
+		{
+			name:      "empty",
+			input:     todoWriteInput{},
+			wantDone:  0,
+			wantTotal: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, _ := json.Marshal(tt.input)
+			got := countFromTodoWrite(raw)
+			if got.Completed != tt.wantDone {
+				t.Errorf("completed = %d, want %d", got.Completed, tt.wantDone)
+			}
+			if got.Total != tt.wantTotal {
+				t.Errorf("total = %d, want %d", got.Total, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestLoadSaveTaskSummary(t *testing.T) {
+	_, cleanup := setupTaskTrackerTest(t)
+	defer cleanup()
+
+	// Load from nonexistent file returns zero
+	got := loadTaskSummary("test-session")
+	if got.Completed != 0 || got.Total != 0 {
+		t.Errorf("expected zero summary, got %+v", got)
+	}
+
+	// Save and reload
+	s := &taskSummary{Completed: 3, Total: 7}
+	saveTaskSummary("test-session", s)
+
+	got = loadTaskSummary("test-session")
+	if got.Completed != 3 || got.Total != 7 {
+		t.Errorf("expected {3,7}, got %+v", got)
+	}
+}
+
+func TestTaskTrackerTaskCreate(t *testing.T) {
+	_, cleanup := setupTaskTrackerTest(t)
+	defer cleanup()
+
+	// Simulate three TaskCreate calls.
+	// We test the logic directly since the hook calls os.Exit.
+	for i := 0; i < 3; i++ {
+		summary := loadTaskSummary("tracker-test")
+		summary.Total++
+		saveTaskSummary("tracker-test", &summary)
+	}
+
+	got := readSummary(t, "tracker-test")
+	if got.Total != 3 {
+		t.Errorf("total = %d, want 3", got.Total)
+	}
+	if got.Completed != 0 {
+		t.Errorf("completed = %d, want 0", got.Completed)
+	}
+}
+
+func TestTaskTrackerTaskUpdateCompleted(t *testing.T) {
+	_, cleanup := setupTaskTrackerTest(t)
+	defer cleanup()
+
+	// Set up initial state: 3 tasks, 0 completed
+	saveTaskSummary("tracker-test", &taskSummary{Total: 3})
+
+	// Simulate TaskUpdate with status=completed
+	summary := loadTaskSummary("tracker-test")
+	var tu taskUpdateInput
+	json.Unmarshal([]byte(`{"status":"completed"}`), &tu)
+	if tu.Status == "completed" {
+		summary.Completed++
+	}
+	saveTaskSummary("tracker-test", &summary)
+
+	got := readSummary(t, "tracker-test")
+	if got.Total != 3 {
+		t.Errorf("total = %d, want 3", got.Total)
+	}
+	if got.Completed != 1 {
+		t.Errorf("completed = %d, want 1", got.Completed)
+	}
+}
+
+func TestTaskTrackerTaskUpdateDeleted(t *testing.T) {
+	_, cleanup := setupTaskTrackerTest(t)
+	defer cleanup()
+
+	// Set up initial state: 3 tasks, 1 completed
+	saveTaskSummary("tracker-test", &taskSummary{Completed: 1, Total: 3})
+
+	// Simulate TaskUpdate with status=deleted
+	summary := loadTaskSummary("tracker-test")
+	var tu taskUpdateInput
+	json.Unmarshal([]byte(`{"status":"deleted"}`), &tu)
+	if tu.Status == "deleted" && summary.Total > 0 {
+		summary.Total--
+	}
+	saveTaskSummary("tracker-test", &summary)
+
+	got := readSummary(t, "tracker-test")
+	if got.Total != 2 {
+		t.Errorf("total = %d, want 2", got.Total)
+	}
+	if got.Completed != 1 {
+		t.Errorf("completed = %d, want 1", got.Completed)
+	}
+}

--- a/internal/installer/steps/config_files.go
+++ b/internal/installer/steps/config_files.go
@@ -218,6 +218,17 @@ func hooksConfig(binPath string) map[string]any {
 					},
 				},
 			},
+			{
+				"matcher": "TaskCreate|TaskUpdate|TodoWrite",
+				"hooks": []map[string]any{
+					{
+						"type":    "command",
+						"command": binPath + " hook task-tracker",
+						"async":   true,
+						"timeout": 15,
+					},
+				},
+			},
 		},
 		"Stop": []map[string]any{
 			{

--- a/internal/statusline/formatter.go
+++ b/internal/statusline/formatter.go
@@ -22,10 +22,17 @@ type Input struct {
 	SessionID  string  `json:"session_id"`
 	ContextPct float64 `json:"context_pct"`
 	Plan       *Plan   `json:"plan"`
+	Tasks      *Tasks  `json:"tasks"`
 	Worktree   *Wt     `json:"worktree"`
 	Duration   int     `json:"duration_secs"`
 	Messages   int     `json:"messages"`
 	Branch     string  `json:"branch"`
+}
+
+// Tasks represents task/todo completion counts.
+type Tasks struct {
+	Completed int `json:"completed"`
+	Total     int `json:"total"`
 }
 
 // Plan represents plan metadata in the status input.
@@ -55,6 +62,10 @@ func Format(input *Input) string {
 
 	if input.Plan != nil {
 		parts = append(parts, formatPlan(input.Plan))
+	}
+
+	if input.Tasks != nil && input.Tasks.Total > 0 {
+		parts = append(parts, formatTasks(input.Tasks))
 	}
 
 	if ctx := formatContext(input.ContextPct); ctx != "" {
@@ -93,6 +104,10 @@ func formatContext(pct float64) string {
 	default:
 		return text
 	}
+}
+
+func formatTasks(t *Tasks) string {
+	return fmt.Sprintf("T:%d/%d", t.Completed, t.Total)
 }
 
 func formatPlan(p *Plan) string {

--- a/internal/statusline/formatter_test.go
+++ b/internal/statusline/formatter_test.go
@@ -139,6 +139,72 @@ func TestFormat_Full(t *testing.T) {
 	}
 }
 
+func TestFormatTasks(t *testing.T) {
+	got := formatTasks(&Tasks{Completed: 2, Total: 5})
+	want := "T:2/5"
+	if got != want {
+		t.Errorf("formatTasks() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatTasks_AllDone(t *testing.T) {
+	got := formatTasks(&Tasks{Completed: 3, Total: 3})
+	want := "T:3/3"
+	if got != want {
+		t.Errorf("formatTasks() = %q, want %q", got, want)
+	}
+}
+
+func TestFormat_WithTasks(t *testing.T) {
+	input := &Input{
+		Branch: "feat/auth",
+		Tasks:  &Tasks{Completed: 1, Total: 4},
+	}
+	got := Format(input)
+	if !strings.Contains(got, "T:1/4") {
+		t.Errorf("Format() should contain T:1/4, got %q", got)
+	}
+	if !strings.Contains(got, "feat/auth") {
+		t.Errorf("Format() should contain branch, got %q", got)
+	}
+	if !strings.Contains(got, "│") {
+		t.Errorf("Format() should have separator, got %q", got)
+	}
+}
+
+func TestFormat_TasksZeroTotal(t *testing.T) {
+	input := &Input{
+		Branch: "main",
+		Tasks:  &Tasks{Completed: 0, Total: 0},
+	}
+	got := Format(input)
+	if strings.Contains(got, "T:") {
+		t.Errorf("Format() should not show tasks with zero total, got %q", got)
+	}
+}
+
+func TestFormat_FullWithTasks(t *testing.T) {
+	input := &Input{
+		Branch:     "feat/auth",
+		ContextPct: 45,
+		Plan:       &Plan{Name: "auth", Status: "PENDING", Done: 1, Total: 4},
+		Tasks:      &Tasks{Completed: 2, Total: 6},
+	}
+	got := Format(input)
+	if !strings.Contains(got, "feat/auth") {
+		t.Errorf("Format() missing branch, got %q", got)
+	}
+	if !strings.Contains(got, "P:auth 1/4") {
+		t.Errorf("Format() missing plan, got %q", got)
+	}
+	if !strings.Contains(got, "T:2/6") {
+		t.Errorf("Format() missing tasks, got %q", got)
+	}
+	if !strings.Contains(got, "45%") {
+		t.Errorf("Format() missing context, got %q", got)
+	}
+}
+
 func TestFormat_Empty(t *testing.T) {
 	input := &Input{}
 	got := Format(input)

--- a/internal/statusline/gather.go
+++ b/internal/statusline/gather.go
@@ -23,6 +23,9 @@ func Gather(input *Input, workDir, sessionDir string) {
 	if input.Plan == nil {
 		input.Plan = gatherPlan(workDir)
 	}
+	if input.Tasks == nil && sessionDir != "" {
+		input.Tasks = gatherTasks(sessionDir)
+	}
 }
 
 // gatherBranch reads the current git branch from .git/HEAD.
@@ -59,6 +62,22 @@ func gatherContextPct(sessionDir string) float64 {
 		return 0
 	}
 	return d.Percentage
+}
+
+// gatherTasks reads the task summary from the session directory.
+func gatherTasks(sessionDir string) *Tasks {
+	data, err := os.ReadFile(filepath.Join(sessionDir, "tasks.json"))
+	if err != nil {
+		return nil
+	}
+	var t Tasks
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil
+	}
+	if t.Total == 0 {
+		return nil
+	}
+	return &t
 }
 
 var (

--- a/internal/statusline/gather_test.go
+++ b/internal/statusline/gather_test.go
@@ -115,6 +115,48 @@ func TestGatherPlan_NoPlans(t *testing.T) {
 	}
 }
 
+func TestGatherTasks(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(
+		filepath.Join(dir, "tasks.json"),
+		[]byte(`{"completed":2,"total":5}`),
+		0o644,
+	)
+
+	got := gatherTasks(dir)
+	if got == nil {
+		t.Fatal("gatherTasks() should return tasks")
+	}
+	if got.Completed != 2 {
+		t.Errorf("tasks.Completed = %d, want 2", got.Completed)
+	}
+	if got.Total != 5 {
+		t.Errorf("tasks.Total = %d, want 5", got.Total)
+	}
+}
+
+func TestGatherTasks_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	got := gatherTasks(dir)
+	if got != nil {
+		t.Errorf("gatherTasks() should return nil when no file, got %+v", got)
+	}
+}
+
+func TestGatherTasks_ZeroTotal(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(
+		filepath.Join(dir, "tasks.json"),
+		[]byte(`{"completed":0,"total":0}`),
+		0o644,
+	)
+
+	got := gatherTasks(dir)
+	if got != nil {
+		t.Errorf("gatherTasks() should return nil for zero total, got %+v", got)
+	}
+}
+
 func TestGatherPlan_VerifiedPlanSkipped(t *testing.T) {
 	dir := t.TempDir()
 	plansDir := filepath.Join(dir, "docs", "plans")


### PR DESCRIPTION
## Summary
- Adds a `task-tracker` PostToolUse hook that intercepts `TaskCreate`, `TaskUpdate`, and `TodoWrite` to persist completed/total counts to `{sessionDir}/tasks.json`
- Statusline now renders `T:completed/total` between plan and context sections (e.g. `feat/auth │ P:auth 1/4 │ T:2/5 │ CTX ▰▰▰▰▱▱▱▱▱▱ 45%`)
- Includes gather logic to read task state from the session directory

Closes #1

## Test plan
- [x] Unit tests for `countFromTodoWrite` with mixed statuses, all completed, deletions, empty
- [x] Unit tests for `loadTaskSummary`/`saveTaskSummary` persistence
- [x] Unit tests for `formatTasks` rendering
- [x] Unit tests for `gatherTasks` including missing file and zero-total cases
- [x] Integration tests for full statusline format with tasks
- [x] All existing tests pass (`go test ./...`)