### PR TITLE
fix: use PAT in auto-tag workflow to trigger release workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Determine version bump
         id: bump


### PR DESCRIPTION
Tags pushed with the default GITHUB_TOKEN do not trigger other workflows. Using the PAT ensures the tag push is treated as a user event, which allows the release workflow to run.