### PR TITLE
fix: remove Explore agent block from tool-redirect hook

### DIFF
--- a/internal/hooks/tool_redirect.go
+++ b/internal/hooks/tool_redirect.go
@@ -1,7 +1,5 @@
 package hooks
 
-import "encoding/json"
-
 func init() {
 	Register("tool-redirect", toolRedirectHook)
 }
@@ -37,32 +35,9 @@ func toolRedirectHook(input *Input) error {
 			},
 		})
 
-	case "Task":
-		if input.ToolInput != nil && isExploreAgent(input.ToolInput) {
-			WriteOutput(&Output{
-				HookSpecific: &HookSpecificOuput{
-					HookEventName:            "PreToolUse",
-					PermissionDecision:       "deny",
-					PermissionDecisionReason: "Do not use the Explore agent. Use vexor search for semantic codebase exploration, or Grep/Glob for exact matches.",
-				},
-			})
-			return nil
-		}
-		ExitOK()
-
 	default:
 		ExitOK()
 	}
 
 	return nil
-}
-
-func isExploreAgent(toolInput []byte) bool {
-	var ti struct {
-		SubagentType string `json:"subagent_type"`
-	}
-	if err := json.Unmarshal(toolInput, &ti); err != nil {
-		return false
-	}
-	return ti.SubagentType == "Explore"
 }

--- a/internal/hooks/tool_redirect_test.go
+++ b/internal/hooks/tool_redirect_test.go
@@ -1,30 +1,6 @@
 package hooks
 
-import (
-	"encoding/json"
-	"testing"
-)
-
-func TestIsExploreAgent(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  bool
-	}{
-		{"explore", `{"subagent_type": "Explore", "prompt": "find files"}`, true},
-		{"general", `{"subagent_type": "general-purpose", "prompt": "research"}`, false},
-		{"empty", `{}`, false},
-		{"invalid", `not json`, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isExploreAgent(json.RawMessage(tt.input))
-			if got != tt.want {
-				t.Errorf("isExploreAgent() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+import "testing"
 
 func TestToolRedirectRegistered(t *testing.T) {
 	_, ok := registry["tool-redirect"]


### PR DESCRIPTION
## Summary
- Removes the `tool-redirect` hook logic that blocked `Task` calls with `subagent_type=Explore`
- The block was redirecting to "vexor search" which may not be available, causing errors
- Removes the unused `isExploreAgent` helper function and its tests

Closes #3

## Test plan
- [x] `go test ./internal/hooks/...` passes
- [x] `go build ./...` passes
- [ ] Verify the Explore agent can be invoked without error