### PR TITLE
fix: remove circular /spec reference from plan mode denial

### DIFF
--- a/internal/hooks/tool_redirect.go
+++ b/internal/hooks/tool_redirect.go
@@ -31,7 +31,7 @@ func toolRedirectHook(input *Input) error {
 			HookSpecific: &HookSpecificOuput{
 				HookEventName:            "PreToolUse",
 				PermissionDecision:       "deny",
-				PermissionDecisionReason: "Do not use built-in plan mode. Use the /spec command instead.",
+				PermissionDecisionReason: "Built-in plan mode is disabled. Do not call EnterPlanMode or ExitPlanMode. Continue working directly without these tools.",
 			},
 		})
 


### PR DESCRIPTION
## Summary
- The `EnterPlanMode` denial message previously said "Use the /spec command instead"
- When `/spec` was active and Claude tried to call `EnterPlanMode`, this created a circular loop — `/spec` tells Claude to plan, Claude calls `EnterPlanMode`, hook says "use /spec", repeat
- Changed the message to simply tell Claude the tool is disabled and to continue without it

Closes #11

## Test plan
- [ ] Run `/spec` with a task description — verify Claude proceeds with planning without hitting the circular error
- [ ] Verify `EnterPlanMode` is still blocked outside of `/spec` context