### PR TITLE
fix: suppress log output by default

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -42,7 +42,7 @@ var serveCmd = &cobra.Command{
 		case err := <-errCh:
 			return err
 		case <-stop:
-			logger.Info("shutting down console server")
+			logger.Debug("shutting down console server")
 			return srv.Stop()
 		}
 	},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,15 +33,20 @@ func Load() (*Config, error) {
 	}, nil
 }
 
+// LevelOff is a log level above LevelError that suppresses all log output.
+const LevelOff = slog.Level(16)
+
 func parseLogLevel(s string) slog.Level {
 	switch strings.ToLower(s) {
 	case "debug":
 		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
 	case "warn", "warning":
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError
 	default:
-		return slog.LevelInfo
+		return LevelOff
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,8 +63,8 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.Port != DefaultPort {
 		t.Errorf("Port = %d, want %d", cfg.Port, DefaultPort)
 	}
-	if cfg.LogLevel != slog.LevelInfo {
-		t.Errorf("LogLevel = %v, want %v", cfg.LogLevel, slog.LevelInfo)
+	if cfg.LogLevel != LevelOff {
+		t.Errorf("LogLevel = %v, want %v", cfg.LogLevel, LevelOff)
 	}
 }
 
@@ -98,8 +98,8 @@ func TestLoad_LogLevels(t *testing.T) {
 		{"warning", slog.LevelWarn},
 		{"error", slog.LevelError},
 		{"info", slog.LevelInfo},
-		{"", slog.LevelInfo},
-		{"unknown", slog.LevelInfo},
+		{"", LevelOff},
+		{"unknown", LevelOff},
 	}
 	for _, tt := range tests {
 		t.Run(tt.env, func(t *testing.T) {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -8,7 +8,8 @@ const (
 	DefaultPort = 41777
 
 	// DefaultLogLevel is the default structured log level.
-	DefaultLogLevel = "info"
+	// "off" disables all log output; users must set PICKY_LOG_LEVEL explicitly to see logs.
+	DefaultLogLevel = "off"
 )
 
 // Version returns the build version string.

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -199,7 +199,7 @@ func (s *Server) Stop() error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	s.logger.Info("console server stopping")
+	s.logger.Debug("console server stopping")
 	if err := s.http.Shutdown(ctx); err != nil {
 		s.db.Close()
 		return err


### PR DESCRIPTION
## Summary
- Default `PICKY_LOG_LEVEL` changed from `info` to `off` so no log messages are shown unless the user explicitly opts in
- Added `LevelOff` constant (`slog.Level(16)`) that sits above `LevelError` to suppress all output
- Demoted "console server stopping" and "shutting down console server" from `Info` to `Debug` since they are routine lifecycle events

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Run `picky run` without `PICKY_LOG_LEVEL` set — verify no log output on stderr
- [ ] Run `PICKY_LOG_LEVEL=info picky run` — verify info-level logs appear
- [ ] Run `PICKY_LOG_LEVEL=debug picky run` — verify debug-level logs (including shutdown messages) appear